### PR TITLE
Transition to `State::Closed` on error.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! If any of the [`Sink`] methods produce an error, the sink transitions to
 //! a closed state. Invoking [`Sink::poll_ready`] or [`Sink::start_send`]
-//! again after an error has occured will cause a *panic*. Invoking
+//! on a sink in closed state will cause a *panic*. Invoking
 //! [`Sink::poll_flush`] or [`Sink::poll_close`] after an error will have no
 //! effect.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # Error behaviour
 //!
-//! If any of the [`Sink`] methods produces an error, the sink transitions to
+//! If any of the [`Sink`] methods produce an error, the sink transitions to
 //! a closed state. Invoking [`Sink::poll_ready`] or [`Sink::start_send`]
 //! again after an error has occured will cause a *panic*. Invoking
 //! [`Sink::poll_flush`] or [`Sink::poll_close`] after an error will have no
@@ -324,4 +324,3 @@ mod tests {
         });
     }
 }
-


### PR DESCRIPTION
Client code may continue to invoke `Sink` methods after encountering an error. The current implementation does not transition to a different state on errors which may cause the repeated invocations to poll the future after completion.

To mitigate this, we now transition to `State::Closed` immediately if an error occurs. This means that clients may then call `poll_flush` or `poll_close` again, but without effect. If on the other hand, client code attempts to keep sending items to the sink via `poll_ready` or `start_send` we enter panic mode as the sink can not be used once it experienced an error.