### PR TITLE
Remove `Error`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.2.0
+# 0.1.2
 
-`SinkImpl` now has its own error type (#4).
+Drop futures after they have resolved. Add another internal state to
+better distinguish failures from ordinary closures.
 
 # 0.1.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicksink"
-version = "0.2.0"
+version = "0.1.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Create a Sink from some value and a closure returning a Future."
 keywords = ["async", "futures", "sink"]


### PR DESCRIPTION
In https://github.com/paritytech/quicksink/pull/4 an error type has been added instead of `panic!` which this PR reverts. While the original motivation is still valid it did not work out in practice. For instance the fact that `SinkExt::sink_map_err` works with `FnOnce` only makes repeated error mapping difficult which defeats the purpose of `Error`.

Therefore this PR goes back to being generic over errors and produces panics when the sink is used wrongly, i.e. if its methods are called again after an error occured or if after `poll_close` other methods are called. Compared to 0.1.1 the only difference in behaviour is that when closing we already panic if `poll_ready` is called and not just when `start_send` is called since an ok from `poll_ready` would indicate that `start_send` could be called which is really not the case.